### PR TITLE
Disable ceilometer for undeployed services

### DIFF
--- a/etc/openstack_deploy/user_heat.yml
+++ b/etc/openstack_deploy/user_heat.yml
@@ -1,2 +1,2 @@
 ---
-heat_ceilometer_enabled: true
+heat_ceilometer_enabled: false

--- a/etc/openstack_deploy/user_magnum.yml
+++ b/etc/openstack_deploy/user_magnum.yml
@@ -1,2 +1,2 @@
 ---
-magnum_ceilometer_enabled: true
+magnum_ceilometer_enabled: false

--- a/etc/openstack_deploy/user_trove.yml
+++ b/etc/openstack_deploy/user_trove.yml
@@ -1,2 +1,2 @@
 ---
-trove_ceilometer_enabled: true
+trove_ceilometer_enabled: false


### PR DESCRIPTION
Configuring ceilometer for undeployed services will only result in extra
unneeded ceilometer work. It's probably why we're pinning so many cores.